### PR TITLE
avocado: limit parallel tasks to 1 with nrunner

### DIFF
--- a/misc/requirements.txt
+++ b/misc/requirements.txt
@@ -1,7 +1,7 @@
-avocado-framework==82.0
-avocado-framework-plugin-loader-yaml==82.0
-avocado-framework-plugin-result-html==82.0
-avocado-framework-plugin-varianter-yaml-to-mux==82.0
+avocado-framework==91.0
+avocado-framework-plugin-loader-yaml==91.0
+avocado-framework-plugin-result-html==91.0
+avocado-framework-plugin-varianter-yaml-to-mux==91.0
 Jinja2==2.11.3
 MarkupSafe==1.1.1
 PyYAML==5.4

--- a/testsuite/multiprocessing_unitary_tests/Makefile
+++ b/testsuite/multiprocessing_unitary_tests/Makefile
@@ -1,4 +1,4 @@
 POK_PATH := $(CURDIR)/../..
 
 check::
-	avocado run  --xunit report.xml --mux-yaml testconfig.yaml -- $(POK_PATH)/misc/execution_test_multiprocessing.py
+	avocado run --nrunner-max-parallel-tasks 1  --xunit report.xml --mux-yaml testconfig.yaml -- $(POK_PATH)/misc/execution_test_multiprocessing.py

--- a/testsuite/unitary_tests/Makefile
+++ b/testsuite/unitary_tests/Makefile
@@ -1,4 +1,4 @@
 POK_PATH := $(CURDIR)/../..
 
 check::
-	avocado run  --xunit report.xml --mux-yaml testconfig.yaml -- $(POK_PATH)/misc/execution_test.py
+	avocado run --nrunner-max-parallel-tasks 1  --xunit report.xml --mux-yaml testconfig.yaml -- $(POK_PATH)/misc/execution_test.py


### PR DESCRIPTION
With version 91.0 Avocado have switched the default runner from
an implementation named internally runner to a new architecture,
that allows parallel execution of tests, called nrunner.
Please, find more info at
https://avocado-framework.readthedocs.io/en/91.0/releases/91_0.html
and
https://avocado-framework.readthedocs.io/en/91.0/guides/contributor/chapters/runners.html?highlight=nrunner-max-parallel-tasks

In the case of pok, you could continue using the legacy runner,
setting --test-runner=runner and sticking to the next LTS version
that will be 92.0 or switch to nrunner and disable
parallel execution by setting --nrunner-max-parallel-tasks 1

Signed-off-by: Ana Guerrero Lopez <anguerre@redhat.com>