### PR TITLE
update arinc653-blackboard, arinc653-buffer, and arinc653-queueing example to conform to AADL standard

### DIFF
--- a/examples/arinc653-blackboard/.project
+++ b/examples/arinc653-blackboard/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>arinc653-blackboard</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/examples/arinc653-blackboard/model.aadl
+++ b/examples/arinc653-blackboard/model.aadl
@@ -20,6 +20,7 @@ public
 
 with Data_Model;
 with POK;
+with ARINC653;
 
 data myint
 properties
@@ -44,10 +45,11 @@ subcomponents
 properties
    POK::Architecture => x86;
    POK::BSP => x86_qemu;
-   POK::Major_Frame => 1000 ms;
+   ARINC653::Module_Major_Frame => 1000 ms;
    POK::Scheduler => static;
-   POK::Slots => (1000 ms);
-   POK::Slots_Allocation => (reference (part1));
+   ARINC653::Module_Schedule => (
+       	[Partition => reference(part1); Duration => 1000ms; Periodic_Processing_Start => true;]
+      );
 end ppc.impl;
 
 process myprocess1
@@ -58,7 +60,7 @@ subcomponents
    thr1 : thread mythread1.impl;
    thr2 : thread mythread2.impl;
 connections
-   port thr1.output -> thr2.input;
+   cnx: port thr1.output -> thr2.input;
 properties
    POK::Needed_Memory_Size => 200 kbyte;
 end myprocess1.impl;
@@ -81,7 +83,7 @@ thread implementation mythread1.impl
 calls 
    call1 : { pspg : subprogram hello_part1;};
 connections
-   parameter pspg.output -> output;
+   cnx: parameter pspg.output -> output;
 properties
    dispatch_protocol => periodic;
    period            => 1000ms;
@@ -91,7 +93,7 @@ thread implementation mythread2.impl
 calls 
    call1 : { pspg : subprogram hello_part2;};
 connections
-   parameter input -> pspg.input;
+   cnx: parameter input -> pspg.input;
 properties
    dispatch_protocol => periodic;
    period            => 500ms;
@@ -102,16 +104,16 @@ features
    output : out parameter myint;
 properties
    source_name => "user_send";
-   source_language => C;
-   POK::Source_Location => "../../../send.o";
+   source_language => (C);
+   Source_Text => ("send.c");
 end hello_part1;
 
 subprogram hello_part2
 features
    input : in parameter myint;
 properties
-   POK::Source_Location => "../../../receive.o";
-   source_language => C;
+   Source_Text => ("receive.c");
+   source_language => (C);
    source_name => "user_receive";
 end hello_part2;
 
@@ -126,4 +128,5 @@ subcomponents
 properties
    Actual_Processor_Binding => (reference (cpu.part1)) applies to part1;
 end node.impl;
+
 end test;

--- a/examples/arinc653-blackboard/model_ramses.aadl
+++ b/examples/arinc653-blackboard/model_ramses.aadl
@@ -1,0 +1,23 @@
+package model_ramses
+public
+	with test;
+	with RAMSES_Properties;
+	
+	system node extends test::node
+	end node;
+
+	system implementation node.ramses extends test::node.impl
+	subcomponents
+		mem: memory mainmemory;
+	properties
+		Scheduling_Protocol => (ARINC653) applies to cpu;
+		Scheduling_Protocol => (POSIX_1003_HIGHEST_PRIORITY_FIRST_PROTOCOL) applies to cpu.part1;
+		Period => 1000ms applies to cpu.part1;
+		RAMSES_Properties::Target => "pok" applies to cpu;
+		Actual_Memory_Binding => (reference(mem)) applies to part1;
+	end node.ramses;
+	
+	memory mainmemory
+	end mainmemory;
+	
+end model_ramses;

--- a/examples/arinc653-blackboard/model_ramses.aadl
+++ b/examples/arinc653-blackboard/model_ramses.aadl
@@ -1,3 +1,16 @@
+--
+--                               POK header
+--
+-- The following file is a part of the POK project. Any modification should
+-- be made according to the POK licence. You CANNOT use this file or a part
+-- of a file for your own project.
+--
+-- For more information on the POK licence, please see our LICENCE FILE
+--
+-- Please follow the coding guidelines described in doc/CODING_GUIDELINES
+--
+--                                      Copyright (c) 2007-2021 POK team
+
 package model_ramses
 public
 	with test;

--- a/examples/arinc653-buffer/.project
+++ b/examples/arinc653-buffer/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>arinc653-buffer</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/examples/arinc653-buffer/model.aadl
+++ b/examples/arinc653-buffer/model.aadl
@@ -21,6 +21,7 @@ public
 
 with Data_Model;
 with POK;
+with ARINC653;
 
 data myint
 properties
@@ -30,7 +31,7 @@ end myint;
 virtual processor partition
 properties
    POK::Scheduler => RR;
-   POK::Additional_Features => (libc_stdio);
+   POK::Additional_Features => (libc_stdio, console);
 end partition;
 
 virtual processor implementation partition.impl
@@ -47,9 +48,10 @@ properties
    POK::Architecture => x86;
    POK::BSP => x86_qemu;
    POK::Scheduler => Static;
-   POK::Major_Frame => 1000 ms;
-   POK::Slots => (500 ms);
-   POK::Slots_Allocation => ( reference (part1));
+   ARINC653::Module_Major_Frame => 1000 ms;
+   ARINC653::Module_Schedule => (
+       	[Partition => reference(part1); Duration => 1000ms; Periodic_Processing_Start => true;]
+      );
 end ppc.impl;
 
 process myprocess1
@@ -60,7 +62,7 @@ subcomponents
    thr1 : thread mythread1.impl;
    thr2 : thread mythread2.impl;
 connections
-   port thr1.output -> thr2.input;
+   cnx: port thr1.output -> thr2.input;
 properties
    POK::Needed_Memory_Size => 200 Kbyte;
 end myprocess1.impl;
@@ -83,7 +85,7 @@ thread implementation mythread1.impl
 calls 
    call1 : { pspg : subprogram hello_part1;};
 connections
-   parameter pspg.output -> output;
+   cnx: parameter pspg.output -> output;
 properties
    dispatch_protocol => periodic;
    period            => 1000 ms;
@@ -93,7 +95,7 @@ thread implementation mythread2.impl
 calls 
    call1 : { pspg : subprogram hello_part2;};
 connections
-   parameter input -> pspg.input;
+   cnx: parameter input -> pspg.input;
 properties
    dispatch_protocol => periodic;
    period            => 1000 ms;
@@ -104,16 +106,16 @@ features
    output : out parameter myint;
 properties
    source_name => "user_send";
-   source_language => C;
-   POK::Source_Location => "../../../send.o";
+   source_language => (C);
+   Source_Text => ("send.c");
 end hello_part1;
 
 subprogram hello_part2
 features
    input : in parameter myint;
 properties
-   POK::Source_Location => "../../../receive.o";
-   source_language => C;
+   Source_Text => ("receive.c");
+   source_language => (C);
    source_name => "user_receive";
 end hello_part2;
 

--- a/examples/arinc653-buffer/model_ramses.aadl
+++ b/examples/arinc653-buffer/model_ramses.aadl
@@ -1,0 +1,25 @@
+package model_ramses
+public
+	with test;
+	with RAMSES_Properties;
+	
+	system node extends test::node
+	end node;
+
+	system implementation node.ramses extends test::node.impl
+	subcomponents
+		mem: memory mainmemory;
+	properties
+		Scheduling_Protocol => (ARINC653) applies to cpu;
+		Scheduling_Protocol => (POSIX_1003_HIGHEST_PRIORITY_FIRST_PROTOCOL) applies to cpu.part1;
+		Period => 1000ms applies to cpu.part1;
+		RAMSES_Properties::Target => "pok" applies to cpu;
+		Actual_Memory_Binding => (reference(mem)) applies to part1;
+	end node.ramses;
+	
+	memory mainmemory
+	properties
+	    Memory_Size => 300000 Bytes;
+	end mainmemory;
+	
+end model_ramses;

--- a/examples/arinc653-buffer/model_ramses.aadl
+++ b/examples/arinc653-buffer/model_ramses.aadl
@@ -1,3 +1,16 @@
+--
+--                               POK header
+--
+-- The following file is a part of the POK project. Any modification should
+-- be made according to the POK licence. You CANNOT use this file or a part
+-- of a file for your own project.
+--
+-- For more information on the POK licence, please see our LICENCE FILE
+--
+-- Please follow the coding guidelines described in doc/CODING_GUIDELINES
+--
+--                                      Copyright (c) 2007-2021 POK team
+
 package model_ramses
 public
 	with test;

--- a/examples/arinc653-queueing/.project
+++ b/examples/arinc653-queueing/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>arinc653-queueing</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/examples/arinc653-queueing/model.aadl
+++ b/examples/arinc653-queueing/model.aadl
@@ -1,19 +1,15 @@
 --
---                              POK header
--- 
---  The following file is a part of the POK project. Any modification should
---  be made according to the POK licence. You CANNOT use this file or a part 
---  of a file for your own project.
--- 
---  For more information on the POK licence, please see our LICENCE FILE
+--                               POK header
 --
---  Please follow the coding guidelines described in doc/CODING_GUIDELINES
+-- The following file is a part of the POK project. Any modification should
+-- be made according to the POK licence. You CANNOT use this file or a part
+-- of a file for your own project.
 --
---                                      Copyright (c) 2007-2009 POK team 
+-- For more information on the POK licence, please see our LICENCE FILE
 --
---  Created by julien on Thu Jan 15 23:34:13 2009 
+-- Please follow the coding guidelines described in doc/CODING_GUIDELINES
 --
-
+--                                      Copyright (c) 2007-2021 POK team
 
 package pingpong
 
@@ -22,7 +18,6 @@ public
 with Data_Model;
 with POK;
 with ARINC653;
-
 
 data integer
 properties
@@ -46,9 +41,10 @@ properties
 end common_bus;
 
 virtual processor partition
-properties
-   ARINC653::HM_Errors => (Partition_Init);
-   ARINC653::HM_Partition_Recovery_Actions => (Warm_Restart);
+	properties
+	ARINC653::HM_Error_ID_Actions => (
+    	[ErrorIdentifier => 1; Description => "Warm partition restart"; Action => "Warm_Restart";]
+      );
    POK::Additional_Features => (libc_stdio, console);
 end partition;
 
@@ -64,16 +60,16 @@ features
    output : out parameter integer;
 properties
    source_name => "user_send";
-   source_language => C;
-   source_text => ("../../../send.o");
+   source_language => (C);
+   source_text => ("send.c");
 end hello_part1;
 
 subprogram hello_part2
 features
    input : in parameter integer;
 properties
-   source_text => ("../../../receive.o");
-   source_language => C;
+   source_text => ("receive.c");
+   source_language => (C);
    source_name => "user_receive";
 end hello_part2;
 
@@ -96,8 +92,16 @@ subcomponents
    partition_common : virtual processor partition.common;
 properties
    ARINC653::Module_Major_Frame => 1000ms;
-   ARINC653::Partition_Slots => (500ms, 500ms);
-   ARINC653::Slots_Allocation => ( reference (partition_secure), reference (partition_common));
+   Period => 500 ms applies to partition_secure, partition_common;
+   ARINC653::Module_Schedule => (
+       	[Partition => reference(partition_secure); Duration => 500ms; Periodic_Processing_Start => true;],
+       	[Partition => reference(partition_common); Duration => 500ms; Periodic_Processing_Start => true;]
+      );
+   ARINC653::HM_Error_ID_Levels => (
+		[ErrorIdentifier => 1; Description => "Partition init error"; ErrorLevel => Partition_Level; ErrorCode => Partition_Init;],
+		[ErrorIdentifier => 2; Description => "Numeric error"; ErrorLevel => Process_Level; ErrorCode => Numeric_Error;]
+	);
+	scheduling_protocol => (POSIX_1003_HIGHEST_PRIORITY_FIRST_PROTOCOL) applies to partition_secure, partition_common; 
 end ppc.impl;
 
 thread receive_ping
@@ -109,11 +113,12 @@ properties
    Dispatch_Protocol => Periodic;
    Compute_Execution_Time => 0 ms .. 1 ms;
    Period => 1000 Ms;
-   ARINC653::HM_Errors => (Numeric_Error);
-   ARINC653::HM_Process_Recovery_Actions => (Warm_Restart);
-   Source_Data_Size => 400000 bytes;
-   Source_Stack_Size => 400000 bytes;
-   Source_Code_Size => 40 bytes;
+   ARINC653::HM_Error_ID_Actions => (
+   	[ErrorIdentifier => 2; Description => "Warm partition restart"; Action => "Warm_Restart";]
+   );
+   Data_Size => 400000 bytes;
+   Stack_Size => 400000 bytes;
+   Code_Size => 40 bytes;
 end receive_ping;
 
 thread send_ping
@@ -124,34 +129,35 @@ properties
    Priority => 1;
    Dispatch_Protocol => Periodic;
    Period => 1000 Ms;
-   Source_Data_Size => 40 bytes;
-   Source_Stack_Size => 40 bytes;
-   Source_Code_Size => 40 bytes;
+   Data_Size => 40 bytes;
+   Stack_Size => 40 bytes;
+   Code_Size => 40 bytes;
    Compute_Execution_Time => 0 ms .. 1 ms;
-   ARINC653::HM_Errors => (Numeric_Error);
-   ARINC653::HM_Process_Recovery_Actions => (Warm_Restart);
+   ARINC653::HM_Error_ID_Actions => (
+   	[ErrorIdentifier => 2; Description => "Warm partition restart"; Action => "Warm_Restart";]
+   );
 end send_ping;
 
 thread implementation send_ping.impl
 calls 
    call1 : { pspg : subprogram hello_part1;};
 connections
-   parameter pspg.output -> tdataout;
+   cnx: parameter pspg.output -> tdataout;
 end send_ping.impl;
 
 thread implementation receive_ping.impl
 calls 
    call1 : { pspg : subprogram hello_part2;};
 connections
-   parameter tdatain -> pspg.input;
+   cnx: parameter tdatain -> pspg.input;
 end receive_ping.impl;
 
 process receive_ping_process
 features
    pdatain : in event data port integer {Allowed_Connection_Binding_Class => (classifier (pingpong::medium_bus)); Queue_Size => 2;}; 
 properties
-   Source_Code_Size => 10 KByte;
-   Source_Data_Size => 15 KByte;
+   Code_Size => 10 KByte;
+   Data_Size => 15 KByte;
 end receive_ping_process;
 
 process send_ping_process
@@ -169,14 +175,14 @@ process implementation receive_ping_process.impl
 subcomponents
    thr : thread receive_ping.impl;
 connections
-   port pdatain -> thr.tdatain; 
+   cnx: port pdatain -> thr.tdatain; 
 end receive_ping_process.impl;
 
 process implementation send_ping_process.impl
 subcomponents
    thr : thread send_ping.impl;
 connections
-   port thr.tdataout -> pdataout;
+   cnx: port thr.tdataout -> pdataout;
 end send_ping_process.impl;
 
 system node
@@ -184,9 +190,8 @@ end node;
 
 memory partitionmemory
 properties
-   Byte_Count => 80000;
-   ARINC653::Memory_Type => (code_memory);
-   ARINC653::Access_Type => read;
+   Memory_Size => 80000 Bytes;
+   ARINC653::Memory_Kind => (Memory_Code);
 end partitionmemory;
 
 memory mainmemory
@@ -195,11 +200,9 @@ end mainmemory;
 memory implementation mainmemory.impl
 subcomponents
    part1: memory partitionmemory 
-               {ARINC653::Memory_Type => (code_memory);
-                ARINC653::Access_Type => read;};
+               {ARINC653::Memory_Kind => (Memory_Code);};
    part2: memory partitionmemory
-               {ARINC653::Memory_Type => (data_memory);
-               ARINC653::Access_Type => write;};
+               {ARINC653::Memory_Kind => (Memory_Code);};
 end mainmemory.impl;
 
 
@@ -211,9 +214,10 @@ subcomponents
    pr2 : process receive_ping_process.impl;
    mem : memory mainmemory.impl;
 connections
-   port pr1.pdataout -> pr2.pdatain
+   cnx: port pr1.pdataout -> pr2.pdatain
       {Allowed_Connection_Binding_Class => (classifier (pingpong::secure_bus));};
 properties
+   Scheduling_Protocol => (Arinc653) applies to cpu;
    actual_processor_binding => 
       (reference (cpu.partition_secure)) applies to pr2;
    actual_processor_binding => 

--- a/examples/arinc653-queueing/model_ramses.aadl
+++ b/examples/arinc653-queueing/model_ramses.aadl
@@ -1,0 +1,14 @@
+package model_ramses
+public
+	with pingpong;
+	with RAMSES_Properties;
+	
+	system node extends pingpong::node
+	end node;
+	
+	system implementation node.ramses extends pingpong::node.impl
+	properties
+		RAMSES_Properties::Target => "pok" applies to cpu;	
+	end node.ramses;
+	
+end model_ramses;

--- a/examples/arinc653-queueing/model_ramses.aadl
+++ b/examples/arinc653-queueing/model_ramses.aadl
@@ -1,3 +1,16 @@
+--
+--                               POK header
+--
+-- The following file is a part of the POK project. Any modification should
+-- be made according to the POK licence. You CANNOT use this file or a part
+-- of a file for your own project.
+--
+-- For more information on the POK licence, please see our LICENCE FILE
+--
+-- Please follow the coding guidelines described in doc/CODING_GUIDELINES
+--
+--                                      Copyright (c) 2007-2021 POK team
+
 package model_ramses
 public
 	with pingpong;


### PR DESCRIPTION
These examples can be imported in OSATE and used with RAMSES to generate code for POK