### PR TITLE
Rename obsolete constants

### DIFF
--- a/examples/middleware-queueing-timed/local_impl/pr1/activity.c
+++ b/examples/middleware-queueing-timed/local_impl/pr1/activity.c
@@ -22,7 +22,7 @@ void *pinger_job() {
   simple_type data_source_request_var;
 
   ret = pok_port_queueing_create("dataout", 8, POK_PORT_DIRECTION_OUT,
-                                 POK_PORT_QUEUEING_DISCIPLINE_FIFO,
+                                 POK_QUEUEING_DISCIPLINE_FIFO,
                                  &port_pinger_data_source_id);
   printf("P1T1: create queue, return=%d\n", ret);
 

--- a/examples/middleware-queueing-timed/local_impl/pr2/activity.c
+++ b/examples/middleware-queueing-timed/local_impl/pr2/activity.c
@@ -28,7 +28,7 @@ void *pingme_job() {
   toto = 0;
 
   ret = pok_port_queueing_create("datain", 8, POK_PORT_DIRECTION_IN,
-                                 POK_PORT_QUEUEING_DISCIPLINE_FIFO,
+                                 POK_QUEUEING_DISCIPLINE_FIFO,
                                  &port_pingme_data_sink);
   printf("P2T1: Create port, return = %d\n", ret);
 

--- a/examples/middleware-queueing/local_impl/pr1/activity.c
+++ b/examples/middleware-queueing/local_impl/pr1/activity.c
@@ -22,7 +22,7 @@ void *pinger_job() {
   simple_type data_source_request_var;
 
   ret = pok_port_queueing_create("dataout", 8, POK_PORT_DIRECTION_OUT,
-                                 POK_PORT_QUEUEING_DISCIPLINE_FIFO,
+                                 POK_QUEUEING_DISCIPLINE_FIFO,
                                  &port_pinger_data_source_id);
   printf("Create queue, return=%d\n", ret);
   printf("port id=%d\n", port_pinger_data_source_id);

--- a/examples/middleware-queueing/local_impl/pr2/activity.c
+++ b/examples/middleware-queueing/local_impl/pr2/activity.c
@@ -28,7 +28,7 @@ void *pingme_job() {
   toto = 0;
 
   ret = pok_port_queueing_create("datain", 8, POK_PORT_DIRECTION_IN,
-                                 POK_PORT_QUEUEING_DISCIPLINE_FIFO,
+                                 POK_QUEUEING_DISCIPLINE_FIFO,
                                  &port_pingme_data_sink);
   printf("Create port, return = %d\n", ret);
 


### PR DESCRIPTION
This has been forgotten in 6c611542971a04b068988e65c15fbf10cf521476.
This should fix #45